### PR TITLE
Update README.md with correct new repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Repository has moved  
-Please see the latest repository here: https://github.com/Club-Seiden/python-for-IBM-i-examples/tree/master/netstat
+Please see the newer repository here: https://github.com/Club-Seiden/python-for-IBM-i-examples/tree/master/non-wheel/netstat


### PR DESCRIPTION
The link to the "new" Python repository was incorrect. I've corrected it.